### PR TITLE
update to ccpa banner

### DIFF
--- a/ui/src/css/oneTrust.css
+++ b/ui/src/css/oneTrust.css
@@ -1,114 +1,42 @@
-body .optanon-alert-box-wrapper {
-  background: rgba(0, 0, 0, 0.9);
-  bottom: 0 !important;
-  min-height: 100%;
-  display: -webkit-box;
-  display: -moz-box;
-  display: -ms-box;
-  display: -webkit-flex;
-  display: flex;
-  -webkit-box-pack: center;
-  -moz-box-pack: center;
-  -o-box-pack: center;
-  -ms-box-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-box-align: center;
-  -moz-box-align: center;
-  -o-box-align: center;
-  -ms-box-align: center;
-  -webkit-align-items: center;
-  align-items: center;
+body #onetrust-pc-sdk .ot-switch {
+    width: 45px !important;
+    padding: 0 !important;
 }
-
-@media screen and (min-width: 600px) {
-  body .optanon-alert-box-wrapper {
-    min-height: 200px;
-  }
+body #onetrust-pc-sdk .ot-switch-nob:before  {
+    transform: translateX(2px); 
 }
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bottom-top {
-  display: none;
+body .onetrust-pc-dark-filter {
+    background: rgba(0,0,0,.75);
 }
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bg {
-  background: transparent url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 144.56 92.97'%3E%3Cdefs%3E%3CradialGradient id='radial-gradient' cx='85.5' cy='12152.5' r='57.84' gradientTransform='translate(7.58 -4685.9) scale(0.97 0.39)' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='0' stop-color='%23f5c47d'/%3E%3Cstop offset='0.32' stop-color='%23f2c079'/%3E%3Cstop offset='0.64' stop-color='%23e8b46f'/%3E%3Cstop offset='0.96' stop-color='%23d8a05d'/%3E%3Cstop offset='1' stop-color='%23d69d5a'/%3E%3C/radialGradient%3E%3CradialGradient id='radial-gradient-2' cx='106.72' cy='60' r='5.5' gradientTransform='translate(7.58 -2.38) scale(0.97)' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='0' stop-color='%23825942'/%3E%3Cstop offset='0.27' stop-color='%237b533e'/%3E%3Cstop offset='0.65' stop-color='%23694433'/%3E%3Cstop offset='1' stop-color='%23523125'/%3E%3C/radialGradient%3E%3CradialGradient id='radial-gradient-3' cx='83.38' cy='10468.18' r='55.22' gradientTransform='translate(7.58 -4408.29) scale(0.97 0.42)' xlink:href='%23radial-gradient'/%3E%3CradialGradient id='radial-gradient-4' cx='91.99' cy='24.08' r='5.88' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-5' cx='42.84' cy='52.39' fx='32.65614254550495' r='49.81' gradientTransform='translate(7.58 -2.38) scale(0.97)' xlink:href='%23radial-gradient'/%3E%3CradialGradient id='radial-gradient-6' cx='57.41' cy='67.04' r='9.36' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-7' cx='44.63' cy='51.56' r='5.78' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-8' cx='38.03' cy='77.47' r='6.74' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-9' cx='13.66' cy='73.48' r='6.28' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-10' cx='10.65' cy='61.79' r='3.78' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-11' cx='60.3' cy='21.56' r='4.71' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-12' cx='21.71' cy='31.79' r='7.65' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-13' cx='119.22' cy='37.38' r='4.63' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-14' cx='123.53' cy='22.63' r='6.52' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-15' cx='133.53' cy='55.95' r='3.02' xlink:href='%23radial-gradient-2'/%3E%3CradialGradient id='radial-gradient-16' cx='82.64' cy='40.19' r='5.94' xlink:href='%23radial-gradient-2'/%3E%3C/defs%3E%3Ctitle%3Ecookies%3C/title%3E%3Cg style='isolation:isolate'%3E%3Cg id='Layer_1' data-name='Layer 1'%3E%3Cpath d='M32.05,57.34C32.46,62,36.33,69.19,54.39,74c19.24,5.1,56.17,2,72.1-2.23,15.16-4,20.79-12,20.79-16.84,0-6.67-7.52-13.31-29.41-16.85S62.79,36.94,52.18,39.6,31.39,49.79,32.05,57.34Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient)'/%3E%3Cpath d='M87.89,76.51c14.94-.49,29.9-2.46,38.6-4.76,15.16-4,20.79-12,20.79-16.84,0-4-2.75-8-9.73-11.37-2,1.56-.42,4.83-.05,7,.62,3.7-2.47,5.7-5.36,7.26-3.36,1.81-6.15,4.06-9.9,4.79-4.43.86-9.89.33-14.37.86-4.73.56-9.44,1.24-14.14,1.94H94c-.55.45-1.09.9-1.59,1.39A15.2,15.2,0,0,0,87.89,76.51Z' transform='translate(-2.72 -3.52)' fill='%23a67741' opacity='0.29' style='mix-blend-mode:multiply'/%3E%3Cpath d='M110.25,61.06c-.48,0-.94,0-1.38,0a5.23,5.23,0,0,1-4.54-3.87,3,3,0,0,1,.76-3.32,8.33,8.33,0,0,0,1-1c.95-1,2.12-2.25,4.06-2.25a5.36,5.36,0,0,1,1.44.22c3.41,1,6.63,4.79,6.63,7.06,0,1.18-1,2.06-3,2.6a20,20,0,0,1-5,.58Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M105,54.27c-1.45,1,0,5.31,3.32,5.54s8.4-.45,8.4-2.23-2.87-5.32-6-6.19S106.56,53.15,105,54.27Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-2)'/%3E%3Cpath d='M31.83,36.06c.54,3.75,4.87,13.53,27.65,17.3s54,2,67.23-2S144.4,39,144.4,34.51,140,18.09,121.18,13.44,77.85,10.11,61,13.89,30.29,25.19,31.83,36.06Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-3)'/%3E%3Cpath d='M108.3,75a83.24,83.24,0,0,0,0-30.82c-1.82-8.65-8.64-20.48-14.86-27.61a33.52,33.52,0,0,0-6.79-5.91c-3.43.15-6.81.42-10.1.77l-9.8,20.16,5,44.83A220.35,220.35,0,0,0,108.3,75Z' transform='translate(-2.72 -3.52)' fill='%23bd8f59' opacity='0.33' style='mix-blend-mode:multiply'/%3E%3Cpath d='M137.51,21.62a9.68,9.68,0,0,1-1.3,6.93c-1.93,2.91-5.74,4.34-8.49,6.35-2.92,2.13-5.55,4.16-9.06,5.22a43.27,43.27,0,0,1-9.93,1.62c-3.09.19-6.61-1-9.57-.54-2.43.35-2.55,3.1-3.32,5.13-.85,2.3-1.79,4.85.14,7a25.77,25.77,0,0,0,2,1.93c11.77-.53,22.34-1.94,28.73-3.86C140,47.37,144.4,39,144.4,34.51,144.4,31.85,142.81,26.49,137.51,21.62Z' transform='translate(-2.72 -3.52)' fill='%23a67741' opacity='0.29' style='mix-blend-mode:multiply'/%3E%3Cpath d='M126.71,51.35C140,47.37,144.4,39,144.4,34.51A15.56,15.56,0,0,0,142,27.05c.49,2.63,1,6.52-.15,8.9a16.78,16.78,0,0,1-7.05,6.82,61.48,61.48,0,0,1-10.93,3.87c-4.5,1.1-8.19,1.84-12.74,2.73-3.61.71-7.51.72-11.15,1.37l-3-2.66a10.42,10.42,0,0,0-1.78,3.84A4.27,4.27,0,0,0,96,53.28a25.77,25.77,0,0,0,2,1.93C109.75,54.68,120.32,53.27,126.71,51.35Z' transform='translate(-2.72 -3.52)' fill='%23785536' opacity='0.37' style='mix-blend-mode:multiply'/%3E%3Cpath d='M126.49,71.75c15.16-4,20.79-12,20.79-16.84,0-2.85-1.38-5.69-4.65-8.29,1.76,3.43,3.43,6.94,1.68,10-1.58,2.79-5.59,5.84-8.42,7.05a125.16,125.16,0,0,1-15.24,5.24c-4.17,1.12-11,1.91-15.24,2.5-4.83.67-10.44.32-15.25.91-3.12.38-2.36,1.3-2.6,4.17C102.6,76.05,117.72,74.07,126.49,71.75Z' transform='translate(-2.72 -3.52)' fill='%23785536' opacity='0.37' style='mix-blend-mode:multiply'/%3E%3Cpath d='M93.27,11.38c-.15,2.66.11,4.95,1.77,7.19,1.88,2.53,4,4.68,5.31,7.56s1.82,6.33,4.36,8.37c2.69,2.16,6.75,1.54,9.94,1,6.41-1.17,16.16-3,18.12-9.85,2.29-8-7.17-10-13.5-10.51-7.18-.61-14-2.89-21.12-3.63-.82-.09-1.65-.16-2.48-.23Z' transform='translate(-2.72 -3.52)' fill='%23d6a253' opacity='0.25' style='mix-blend-mode:screen'/%3E%3Cpath d='M94.2,27h-.36A5.15,5.15,0,0,1,90,25a5.87,5.87,0,0,1-1.22-4.61c.47-1.79,4.24-4,8-4,4,0,6.65,3,6.65,5C103.43,23.54,97.74,27,94.2,27Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M90,19.65c.32-1.31,3.54-3.56,7.09-3.56s5.74,2.9,5.74,4.45-5.31,5.32-8.63,5.09S89.56,21.43,90,19.65Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-4)'/%3E%3Cpath d='M104,41.26C100.63,25.22,89.53,14,85.5,10.69c-3,.16-6,.39-9,.7l-9.8,20.16,5,44.83a210.92,210.92,0,0,0,29.14-.66C105.18,67.09,107,55,104,41.26Z' transform='translate(-2.72 -3.52)' fill='%23bd8f59' opacity='0.33' style='mix-blend-mode:multiply'/%3E%3Cpath d='M69.2,4.57C76.52,5.82,87.58,9.67,95.75,25s8.85,33.7-1.33,49.88S60.59,97.48,42.89,96.36,7.06,84,3.3,59.34,14.81,19.43,23.65,13.66,47.1.81,69.2,4.57Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-5)'/%3E%3Cpath d='M78.34,36.36C75.05,30.25,64.05,29.81,61,25.78,57,20.6,56.64,11.84,50.06,10.34c-5.34-1.22-10.63.33-15.67,2C27.05,14.82,20.6,18.7,16.18,25.43a50.44,50.44,0,0,0-7.63,22c-.74,6.5-.37,13.9,5.21,18.1,5.41,4.08,12.46,6.45,18.36,9.78,7.19,4,15.46,6.16,23.35,3.35A51.93,51.93,0,0,0,77,63.91C83,56.83,83,44.94,78.34,36.36ZM26.47,64.09C24.36,67.48,14,66.42,12.08,58.17c-1-4.18-1.49-11.65,2.75-12.28S28.59,60.71,26.47,64.09Zm48.69-9.74c-3.6-.63-6.33-6.54-4.23-8,1.48-1.06,3.81-2.75,5.29-.64S78.77,55,75.16,54.35Z' transform='translate(-2.72 -3.52)' fill='%23d6a440' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M63.36,72.12c-1.54,0-5.78-.29-6.86-1.65-1-1.18-3.59-6.77-3.06-9.38s6.16-8,11.69-8.26h.16c3.49,0,8.28,4.7,8.53,8.38.25,3.88-5,9.45-7.17,10.42A8.88,8.88,0,0,1,63.36,72.12Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M64.56,53.59c2.88-.13,7.51,4.2,7.74,7.53s-4.65,8.63-6.63,9.53-8.17.22-9.07-.9-3.32-6.42-2.88-8.63S59.48,53.79,64.56,53.59Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-6)'/%3E%3Cpath d='M47.75,53.77a4.18,4.18,0,0,1-1.87-.42,3.36,3.36,0,0,1-1.78-3c-.23-3,1.89-7.33,3-8.11a4,4,0,0,1,2.32-.65c2.17,0,4.74,1.19,6.12,1.83.26.12.47.22.61.27a2.78,2.78,0,0,1,1.55,1.8,3.69,3.69,0,0,1-.47,3.11c-.88,1.32-5.81,5.15-9.47,5.15Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M47.31,42.7c-1.14.81-4.42,8-1.32,9.54s9.28-3.1,10.17-4.43.44-3.11-.66-3.55S49.53,41.15,47.31,42.7Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-7)'/%3E%3Cpath d='M45.55,80a18.68,18.68,0,0,1-2.48-.18,6.82,6.82,0,0,1-5.84-5.34,9.06,9.06,0,0,1,2.49-7.57,8.58,8.58,0,0,1,5.18-1.56,6.94,6.94,0,0,1,4.66,1.57c1.85,1.7,2.67,5.55,2.51,8.31-.1,1.67-.53,2.79-1.27,3.31A8.7,8.7,0,0,1,45.55,80Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M40,67.31A8.19,8.19,0,0,0,37.81,74a5.91,5.91,0,0,0,5.08,4.66c3.32.44,5.53,0,7.08-1.12s1.11-8-1.33-10.21S41.57,66,40,67.31Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-8)'/%3E%3Cpath d='M19.17,75.57a4.93,4.93,0,0,1-3.71-2c-1.27-1.52-2.06-3.59-1.84-4.81.51-2.84,6.17-6.3,8.66-6.3h.29a8.64,8.64,0,0,1,4.94,3.15,2.81,2.81,0,0,1,.72,2.13c-.27,1.68-5.41,7.59-8.78,7.85Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M14.36,68.43c-.28,1.54,2,6,4.87,5.76s7.74-5.76,8-7.09-2.87-4-4.87-4.22S14.81,66,14.36,68.43Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-9)'/%3E%3Cpath d='M18.42,61.57c-1.7,0-4.68-.49-5.09-2.33a5.14,5.14,0,0,1,4.58-6h.26c2.15,0,4.13,2.15,4.74,4.13a2.76,2.76,0,0,1-.89,3.3,6.79,6.79,0,0,1-3.6.89Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M13.92,58.9c.35,1.58,5.31,2.22,7.3.87s-.89-6-3.54-5.75A4.22,4.22,0,0,0,13.92,58.9Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-10)'/%3E%3Cpath d='M66.05,23.81c-1.91,0-5.78-2.93-5.78-5.34s4.25-5.13,6-5.13c3.28,0,5.06,2.84,5.33,5.48a3.44,3.44,0,0,1-1,2.66A7.15,7.15,0,0,1,66.05,23.81Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M66.1,14.1c-1.32,0-5.07,2.44-5.07,4.22s3.31,4.43,4.86,4.43,4.87-2,4.63-4S69,14.1,66.1,14.1Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-11)'/%3E%3Cpath d='M29,36.78a2.64,2.64,0,0,1-.51,0c-1.75-.26-7-3.45-7.8-5.67-.74-2-.32-5.69.8-7.1a11.37,11.37,0,0,1,6-3.23h.44c3,0,5.4,2.12,7.3,3.83l.45.4c2.3,2.07,2.19,6.36.57,8.55-1.47,2-5.32,3.27-7.21,3.27Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M27.19,21.2a10.53,10.53,0,0,0-5.31,2.88c-.88,1.11-1.32,4.45-.66,6.21s5.53,4.87,7.07,5.1,5.54-1.11,6.86-2.88,1.55-5.54-.44-7.32S30.29,21,27.19,21.2Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-12)'/%3E%3Cpath d='M122.6,38.85a5.54,5.54,0,0,1-3.91-1.34,3.8,3.8,0,0,1-.78-3.56c.35-1.85,1.53-4.18,2.75-4.72a4.84,4.84,0,0,1,1.92-.38c2.36,0,5,1.49,5.51,2.72a6,6,0,0,1-1,5.68,6.18,6.18,0,0,1-4.48,1.6Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M120.52,29.62c-1.28.59-3.54,5.54-1.77,7.32s6,1.32,7.3-.23a5.62,5.62,0,0,0,.88-5.09C126.49,30.52,123,28.53,120.52,29.62Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-13)'/%3E%3Cpath d='M126.86,26.88a5.47,5.47,0,0,0,1.15-.12c3.46-.75,6.24-4.13,6.24-6.43a4.43,4.43,0,0,0-.35-1.53,38.48,38.48,0,0,0-9.64-4.49,14.18,14.18,0,0,0-2.55,2.21c-1.69,1.89-2.51,3.91-2.32,5.67.23,2.11,4.35,4.69,7.47,4.69Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M120.3,21.64c.17,1.56,4.42,4.44,7.52,3.78s5.52-3.78,5.52-5.54-3.09-6-5.3-6.44S119.86,17.65,120.3,21.64Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-14)'/%3E%3Cpath d='M138.08,55.11c-1.9,0-4.36-.83-5-2.17a2.25,2.25,0,0,1,.17-2.09,4.35,4.35,0,0,1,3.44-2.09l.38,0a5,5,0,0,1,4.25,2.62A2.42,2.42,0,0,1,141,54a3.71,3.71,0,0,1-2.91,1.08Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M133.13,52.24c.66,1.35,5.08,2.44,6.41.89s-1.33-4-3.54-3.77S132.68,51.35,133.13,52.24Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-15)'/%3E%3Cpath d='M95.75,25C87.58,9.67,76.52,5.82,69.2,4.57a67.46,67.46,0,0,0-20-.56c9.13.86,20.41,3.52,22.26,5.54C74,12.28,83.57,23.2,85.61,25.94s7.51,13.42,7.74,18S92,63.48,87.66,67.57,66.5,79.63,61.72,83.73c-3.17,2.72-26,5.38-30.26,1.13-3.18-3.18-11.6-4.32-15-5.91a85.45,85.45,0,0,1-8.86-5.56c7.26,15,21.42,22.11,35.31,23,17.7,1.12,41.37-5.31,51.53-21.51S103.93,40.27,95.75,25Z' transform='translate(-2.72 -3.52)' fill='%23a67741' opacity='0.29' style='mix-blend-mode:multiply'/%3E%3Cpath d='M87.33,43.16a5.92,5.92,0,0,1-.84,0c-3.88-.53-5.91-4.82-5.65-7.65s3.65-5.38,5.71-5.49h.27a6.45,6.45,0,0,1,4.82,2.43c1.75,2,2.67,4.62,2.51,5.93-.29,2.19-3.39,4.84-6.82,4.84Z' transform='translate(-2.72 -3.52)' fill='%23f0dcc0' opacity='0.29' style='mix-blend-mode:overlay'/%3E%3Cpath d='M86.45,30.72c-1.55.09-4.63,2.24-4.86,4.67s1.55,6.21,4.86,6.67,6.42-2.24,6.65-4S90.67,30.52,86.45,30.72Z' transform='translate(-2.72 -3.52)' fill='url(%23radial-gradient-16)'/%3E%3Cpath d='M83.39,10.34c1,1.82,2.11,3.56,3,5.36.55,1,1.1,2.09,1.64,3.14,4.65,9,9.32,13.44,9.84,23.7.49,9.86-2.94,25-9.76,32.36a56.28,56.28,0,0,1-26,15.88c-9.6,2.49-20.33,1.8-30.13-.37-7.78-1.72-14.36-5.89-20.58-10.61,7.8,10.59,19.7,15.83,31.42,16.56,17.7,1.12,41.37-5.31,51.53-21.51S103.93,40.27,95.75,25A41.29,41.29,0,0,0,83.39,10.34Z' transform='translate(-2.72 -3.52)' fill='%23785536' opacity='0.37' style='mix-blend-mode:multiply'/%3E%3Cpath d='M64.08,55.06c-2,.19-8.27,3.94-8.27,5.58s.51,6.39,3.27,6.56,5-3.12,6.21-6.24S65.8,54.9,64.08,55.06Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M40.94,68.26c-.68.68-1.82,5-1.06,6.37s5.61-.46,6.67-2.73,1.22-3.79-.6-4.25S41.85,67.35,40.94,68.26Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M48.07,43.38c-.6.6-2.43,5.46-1.67,6.37s5.61-3,5.92-4.4S48.83,42.62,48.07,43.38Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M22.74,24.27c-.53.53-1.06,5.16.61,6.07a6.25,6.25,0,0,0,5.91-.16c1.52-1.06,3.49-5,2.12-6.52S24.71,22.3,22.74,24.27Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M16.52,55.36c-.82.5-2.42,2.73-1.06,3.34s4.4-2.28,3.94-3.19S17.28,54.91,16.52,55.36Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M15.61,68.26c-.19.86,1.82,3.94,2.73,3.94s5.77-7.74,3.64-8S15.91,66.89,15.61,68.26Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M86.75,32c-1.12-.28-3.64,1.37-3.8,3.19s1.07,3.64,2.28,3.49S88.57,32.46,86.75,32Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M65.82,15c-1,.39-3,1.82-3,3.33,0,.93,2,2.73,3.19,1.82S66.58,14.71,65.82,15Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M95.39,16.68C93.69,17,93,19.26,94.64,20s4.7-1.37,4.39-2.43S97.07,16.38,95.39,16.68Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M120.88,30.34c-1.07,1.06-2.58,4.54-1.07,5s4.71-2.88,4.26-4.09A2.37,2.37,0,0,0,120.88,30.34Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M126.79,14.41c-1.37.25-6.07,5.46-5.16,6.67s3.64,2.73,5.46,1.82S128.46,14.11,126.79,14.41Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M135.59,50.05c-.84.28-2.43,1.22-.61,2s2.73-.16,2.43-.91A1.86,1.86,0,0,0,135.59,50.05Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M107.53,56c-.94.56-1.52,2.43.75,2.73s4.26-1.67,3.8-2.58S108.28,55.51,107.53,56Z' transform='translate(-2.72 -3.52)' fill='%23faccaa' opacity='0.37' style='mix-blend-mode:screen'/%3E%3Cpath d='M71.05,22.29c-2,1.48-.23,6.16,3.64,5.7S78.34,16.82,71.05,22.29Z' transform='translate(-2.72 -3.52)' fill='%23d6a440' opacity='0.37' style='mix-blend-mode:screen'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E") no-repeat 0 0;
-  background-size: 80px 50px;
-  display: -webkit-box;
-  display: -moz-box;
-  display: -ms-box;
-  display: -webkit-flex;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -moz-box-orient: vertical;
-  -o-box-orient: vertical;
-  -ms-box-orient: vertical;
-  -webkit-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-align: start;
-  -moz-box-align: start;
-  -o-box-align: start;
-  -ms-box-align: start;
-  -webkit-align-items: flex-start;
-  align-items: flex-start;
-  -webkit-box-pack: center;
-  -moz-box-pack: center;
-  -o-box-pack: center;
-  -ms-box-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding: 0 0 0 90px;
-  margin: 1rem 1rem 1rem 1rem;
-  border: 0 solid #69af04;
-  max-width: 660px;
+body #onetrust-button-group {
+    display: flex !important;
+    flex-direction: row-reverse !important;
+    justify-content: flex-end !important;
+    text-align: left !important;
 }
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bg .optanon-clearfix {
-  display: none;
+body #onetrust-accept-btn-handler {
+    opacity: 1 !important;
+    transition: all 300ms ease-in-out;
+    outline: none !important;
 }
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bg .optanon-alert-box-logo {
-  display: none;
+body #onetrust-pc-sdk #close-pc-btn-handler.ot-close-icon {
+    outline: none !important;
 }
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bg .optanon-alert-box-body {
-  background: none;
-  display: block;
-  position: relative;
-  margin: 0 0 1rem 0;
-  padding: 0 0 0.5rem 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+body #onetrust-accept-btn-handler:hover {
+    background-color: #107f9b !important;
+    border-color: #107f9b !important;
+    transition: all 300ms ease-in-out;
 }
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bg .optanon-alert-box-body p {
-  text-shadow: 2px 2px 4px #000;
+body .ot-pc-footer-logo {
+    display: none;
 }
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bg .optanon-alert-box-button-container {
-  display: -webkit-box;
-  display: -moz-box;
-  display: -ms-box;
-  display: -webkit-flex;
-  display: flex;
-  position: relative;
-  margin: 0;
-  padding: 0;
-  left: 0;
-  top: 0;
+body #onetrust-pc-sdk .ot-cat-grp .ot-always-active {
+    color: #6cc04a;
 }
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bg .optanon-alert-box-button-container .optanon-alert-box-button {
-  float: none;
+body #onetrust-pc-sdk .ot-tgl input:checked+.ot-switch .ot-switch-nob {
+    border-color: #6cc04a;
+    background-color: #d4e8cb;
 }
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bg .optanon-alert-box-button-container .optanon-button-more .cookie-settings-button {
-  text-decoration: underline;
-}
-
-body .optanon-alert-box-wrapper .optanon-button-more .optanon-alert-box-button-middle {
-  padding: 10px 10px 0 16px;
-}
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bg .optanon-alert-box-button-container .optanon-button-more .cookie-settings-button:focus {
-  outline: none;
+body #onetrust-pc-sdk .ot-tgl input:checked+.ot-switch .ot-switch-nob:before {
+    background-color: #6cc04a;
 }

--- a/ui/src/css/oneTrust.css
+++ b/ui/src/css/oneTrust.css
@@ -1,42 +1,52 @@
 body #onetrust-pc-sdk .ot-switch {
-    width: 45px !important;
-    padding: 0 !important;
+  width: 45px !important;
+  padding: 0 !important;
 }
-body #onetrust-pc-sdk .ot-switch-nob:before  {
-    transform: translateX(2px); 
+
+body #onetrust-pc-sdk .ot-switch-nob::before {
+  transform: translateX(2px);
 }
+
 body .onetrust-pc-dark-filter {
-    background: rgba(0,0,0,.75);
+  background: rgba(0, 0, 0, 0.75);
 }
+
 body #onetrust-button-group {
-    display: flex !important;
-    flex-direction: row-reverse !important;
-    justify-content: flex-end !important;
-    text-align: left !important;
+  display: flex !important;
+  flex-direction: row-reverse !important;
+  justify-content: flex-end !important;
+  text-align: left !important;
 }
+
 body #onetrust-accept-btn-handler {
-    opacity: 1 !important;
-    transition: all 300ms ease-in-out;
-    outline: none !important;
+  opacity: 1 !important;
+  transition: all 300ms ease-in-out;
+  outline: none !important;
 }
+
 body #onetrust-pc-sdk #close-pc-btn-handler.ot-close-icon {
-    outline: none !important;
+  outline: none !important;
 }
+
 body #onetrust-accept-btn-handler:hover {
-    background-color: #107f9b !important;
-    border-color: #107f9b !important;
-    transition: all 300ms ease-in-out;
+  background-color: #107f9b !important;
+  border-color: #107f9b !important;
+  transition: all 300ms ease-in-out;
 }
+
 body .ot-pc-footer-logo {
-    display: none;
+  display: none;
 }
+
 body #onetrust-pc-sdk .ot-cat-grp .ot-always-active {
-    color: #6cc04a;
+  color: #6cc04a;
 }
-body #onetrust-pc-sdk .ot-tgl input:checked+.ot-switch .ot-switch-nob {
-    border-color: #6cc04a;
-    background-color: #d4e8cb;
+
+body #onetrust-pc-sdk .ot-tgl input:checked + .ot-switch .ot-switch-nob {
+  border-color: #6cc04a;
+  background-color: #d4e8cb;
 }
-body #onetrust-pc-sdk .ot-tgl input:checked+.ot-switch .ot-switch-nob:before {
-    background-color: #6cc04a;
+
+body #onetrust-pc-sdk .ot-tgl input:checked + .ot-switch .ot-switch-nob::before {
+  background-color: #6cc04a;
 }

--- a/ui/src/partials/footer.hbs
+++ b/ui/src/partials/footer.hbs
@@ -3,7 +3,7 @@
   <div class="footer-box">
     <footer class="footer">
       <div class="footer-logo"><a href="https://cloudstate.io"><img src="{{uiRootPath}}/img/cloudstate-color.svg"></a></div>
-      <div class="footer-content">© Cloudstate <script>document.write(new Date().getFullYear());</script> | <a href="https:///cloudstate.io/privacy/">Privacy Policy</a> | <a class="optanon-toggle-display">Cookie Settings</a></div>
+      <div class="footer-content">© Cloudstate <script>document.write(new Date().getFullYear());</script> | <a href="https://www.lightbend.com/legal/privacy" target="_blank">Privacy Policy</a> | <a href="https://cloudstate.io/cookie">Cookie Listing</a> | <a class="optanon-toggle-display">Cookie Settings</a></div>
     </footer>
   </div>
 </div>

--- a/ui/src/partials/head-scripts-youtube-embed.hbs
+++ b/ui/src/partials/head-scripts-youtube-embed.hbs
@@ -9,12 +9,12 @@
 			var queryString = anchor[0].search;
 			let params = new URLSearchParams(queryString);
 			ytID = params.get("v");
-			$(this).before('<div class="flex-video-wrapper"><div class="flex-video"><div id="yt-'+ytID+'" class="cookie-warning youtube-warning"><a class="optanon-allow-all">Accept cookies to view video</a><span>Alternatively you can watch the video <a href="'+ytURL+'" target="_blank">here on YouTube</a></span></div></div></div>');
+			$(this).before('<div class="flex-video-wrapper"><div class="flex-video"><div id="yt-'+ytID+'" class="cookie-warning youtube-warning"><a class="optanon-allow-all" onclick="OneTrust.AllowAll();">Accept cookies to view video</a><span>Alternatively you can watch the video <a href="'+ytURL+'" target="_blank">here on YouTube</a></span></div></div></div>');
 			$(this).removeAttr("href").removeClass("yt-widget").addClass("yt-widget-hide");
 		});
 
 		$( ".youtube-warning" ).each(function( index ) {
-			Optanon.InsertHtml('<iframe id="player" class="youtube-embed-player" src="//www.youtube.com/embed/'+ytID+'?rel=0&modestbranding=0" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>', 'yt-'+ytID, null, {deleteSelectorContent: true}, 4);
+			OneTrust.InsertHtml('<iframe id="player" class="youtube-embed-player" src="//www.youtube.com/embed/'+ytID+'?rel=0&modestbranding=0" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>', 'yt-'+ytID, null, {deleteSelectorContent: true}, '4');
 		});
 	}
 </script>

--- a/ui/src/partials/head-scripts.hbs
+++ b/ui/src/partials/head-scripts.hbs
@@ -1,2 +1,2 @@
 <!--Head Scripts -->
-<script src="https://cdn.cookielaw.org/consent/a14b53db-7715-45da-be81-7fd0cafc385d.js" type="text/javascript" charset="UTF-8"></script>
+<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="c3a30abe-4934-45a2-ba48-823fa026fc64" ></script>


### PR DESCRIPTION
@pvlugter this updates the Cloudstate Antora theme to use an upgraded cookie preference center that now uses geo-location to provide the visitor with a customized experience for Californians (CCPA). The rest of the world sees GDPR complainant preference center.

If you need to test locally and get annoyed by the 'accept cookies' overlay that appears each time the page refreshes, you can add `-test` to the end of the ID `c3a30abe-4934-45a2-ba48-823fa026fc64` that appears in the script include in the `head-scripts.hbs`. Just remember to not commit it as the live version needs the clean ID. 

`<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="c3a30abe-4934-45a2-ba48-823fa026fc64" ></script>`

becomes

`<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="c3a30abe-4934-45a2-ba48-823fa026fc64-test" ></script>` 


![screenshot-localhost_8000-2021 01 13-15_03_04](https://user-images.githubusercontent.com/1418129/104521259-61019c80-55b1-11eb-8fc3-51acf0245244.png)
